### PR TITLE
feat(discovery): TMDB film cards, /discovery command, configurable sort

### DIFF
--- a/alembic/versions/c4a8f0d2e7b1_add_torrent_sort_keywords.py
+++ b/alembic/versions/c4a8f0d2e7b1_add_torrent_sort_keywords.py
@@ -1,0 +1,30 @@
+"""add torrent_sort_keywords to config
+
+Revision ID: c4a8f0d2e7b1
+Revises: 920906cdff50
+Create Date: 2026-04-25 16:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c4a8f0d2e7b1'
+down_revision: Union[str, Sequence[str], None] = '920906cdff50'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('config', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('torrent_sort_keywords', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('config', schema=None) as batch_op:
+        batch_op.drop_column('torrent_sort_keywords')

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -262,6 +262,7 @@ export interface ConfigSetupRequest {
   torrent: TorrentConfig
   tmdb_api_key?: string
   tmdb_session_id?: string
+  torrent_sort_keywords?: string
   seed_ratio_limit?: number
   seed_time_limit?: number
   inactive_seeding_time_limit?: number

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -43,7 +43,10 @@ export const Tooltip = ({
       {isVisible && (
         <div
           className={twMerge(
-            'absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2.5 py-1 text-xs font-medium text-white bg-zinc-900 border border-zinc-800 rounded shadow-xl whitespace-nowrap z-50 pointer-events-none animate-in fade-in zoom-in-95 duration-200',
+            // `max-w-xs` + normal wrapping so long content stays inside the viewport
+            // instead of overflowing past the modal edge; short content still renders
+            // on a single line because there's nothing forcing it to wrap.
+            'absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2.5 py-1 text-xs font-medium text-white bg-zinc-900 border border-zinc-800 rounded shadow-xl max-w-xs text-center z-50 pointer-events-none animate-in fade-in zoom-in-95 duration-200',
             className,
           )}
         >

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -27,6 +27,10 @@
     "no_overview": "No overview available.",
     "your_rating": "Your Rating",
     "rated": "Rating saved!",
+    "rating_removed": "Rating removed",
+    "subscribe": "Subscribe",
+    "subscribed": "Subscribed successfully",
+    "search_on_rutor": "Search on rutor",
     "recommendations": "Similar Movies"
   },
   "sidebar": {

--- a/frontend/src/pages/Discovery.tsx
+++ b/frontend/src/pages/Discovery.tsx
@@ -296,11 +296,11 @@ const MediaModal = ({
 
             {displayMedia.number_of_seasons ? (
               <span>
-                {`📺 ${displayMedia.number_of_seasons} ${
+                {`📺 ${String(displayMedia.number_of_seasons)} ${
                   displayMedia.number_of_seasons === 1 ? 'season' : 'seasons'
                 }${
                   displayMedia.number_of_episodes
-                    ? `, ${displayMedia.number_of_episodes} ep.`
+                    ? `, ${String(displayMedia.number_of_episodes)} ep.`
                     : ''
                 }`}
               </span>
@@ -459,9 +459,7 @@ const MediaModal = ({
             The category dropdown is needed for Subscribe (it picks a target category) —
             kept slim and tucked next to the rss icon. */}
         <div className="flex flex-wrap justify-end items-center gap-2 pt-4 border-t border-zinc-800">
-          <Tooltip
-            content={inWatchlist ? 'In Watchlist' : 'Add to Watchlist'}
-          >
+          <Tooltip content={inWatchlist ? 'In Watchlist' : 'Add to Watchlist'}>
             <Button
               variant="outline"
               size="icon"

--- a/frontend/src/pages/Discovery.tsx
+++ b/frontend/src/pages/Discovery.tsx
@@ -23,6 +23,7 @@ import axios from 'axios'
 import { Button } from 'components/ui/Button'
 import { Modal } from 'components/ui/Modal'
 import { Select } from 'components/ui/Select'
+import { Tooltip } from 'components/ui/Tooltip'
 import { useDebounce } from 'hooks/useDebounce'
 import {
   Check,
@@ -240,12 +241,17 @@ const MediaModal = ({
     }
   }
 
+  const localizedTitle = displayMedia.title || displayMedia.name || 'Unknown'
+  const originalTitle =
+    displayMedia.original_title || displayMedia.original_name
+  // Modal title: `original / ru_ru` when distinct, single title otherwise.
+  const modalTitle =
+    originalTitle && originalTitle !== localizedTitle
+      ? `${originalTitle} / ${localizedTitle}`
+      : localizedTitle
+
   return (
-    <Modal
-      isOpen={true}
-      onClose={onClose}
-      title={displayMedia.title || displayMedia.name || 'Unknown'}
-    >
+    <Modal isOpen={true} onClose={onClose} title={modalTitle}>
       <div className="space-y-5">
         <div className="aspect-video w-full rounded-lg overflow-hidden bg-black/20 relative">
           <img
@@ -283,6 +289,21 @@ const MediaModal = ({
 
             {displayMedia.runtime ? (
               <span>{formatRuntime(displayMedia.runtime)}</span>
+            ) : displayMedia.episode_run_time &&
+              displayMedia.episode_run_time[0] ? (
+              <span>{formatRuntime(displayMedia.episode_run_time[0])}/ep</span>
+            ) : null}
+
+            {displayMedia.number_of_seasons ? (
+              <span>
+                {`📺 ${displayMedia.number_of_seasons} ${
+                  displayMedia.number_of_seasons === 1 ? 'season' : 'seasons'
+                }${
+                  displayMedia.number_of_episodes
+                    ? `, ${displayMedia.number_of_episodes} ep.`
+                    : ''
+                }`}
+              </span>
             ) : null}
 
             {displayMedia.production_countries &&
@@ -297,14 +318,18 @@ const MediaModal = ({
                             : ''
                         })
                       : ''
+                    // Use the project Tooltip component instead of the HTML `title` —
+                    // gives a styled bubble matching the rest of the UI rather than
+                    // the OS default that briefly flashed an empty `?` indicator.
                     return (
-                      <span
+                      <Tooltip
                         key={c.iso_3166_1 || c.name}
-                        title={c.name}
-                        className="cursor-help text-base leading-none select-none opacity-80 hover:opacity-100 transition-opacity"
+                        content={c.name || c.iso_3166_1 || 'Unknown'}
                       >
-                        {flag}
-                      </span>
+                        <span className="text-base leading-none select-none opacity-80 hover:opacity-100 transition-opacity">
+                          {flag || '🏳️'}
+                        </span>
+                      </Tooltip>
                     )
                   })}
                 </div>
@@ -373,6 +398,34 @@ const MediaModal = ({
           <p className="text-zinc-300 text-sm leading-relaxed">
             {displayMedia.overview || t('discovery.no_overview')}
           </p>
+
+          {(() => {
+            const directors = (displayMedia.credits?.crew || [])
+              .filter((c) => c.job === 'Director')
+              .map((c) => c.name)
+              .filter(Boolean)
+            if (!directors.length) return null
+            return (
+              <div className="text-sm text-zinc-300">
+                <span className="text-zinc-500">🎭 Director: </span>
+                {directors.join(', ')}
+              </div>
+            )
+          })()}
+
+          {(() => {
+            const cast = (displayMedia.credits?.cast || [])
+              .slice(0, 6)
+              .map((c) => c.name)
+              .filter(Boolean)
+            if (!cast.length) return null
+            return (
+              <div className="text-sm text-zinc-300">
+                <span className="text-zinc-500">👥 Cast: </span>
+                {cast.join(', ')}
+              </div>
+            )
+          })()}
         </div>
 
         {/* Rating Section */}
@@ -401,29 +454,30 @@ const MediaModal = ({
           </div>
         </div>
 
-        <div className="flex justify-end gap-3 pt-4 border-t border-zinc-800">
-          <Button variant="ghost" onClick={onClose}>
-            {t('common.close')}
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => {
-              void handleWatchlist()
-            }}
+        {/* Action row: square icon-only buttons with tooltips. Modal has its own
+            close ✕ in the top-right, so we drop the redundant Close text button.
+            The category dropdown is needed for Subscribe (it picks a target category) —
+            kept slim and tucked next to the rss icon. */}
+        <div className="flex flex-wrap justify-end items-center gap-2 pt-4 border-t border-zinc-800">
+          <Tooltip
+            content={inWatchlist ? 'In Watchlist' : 'Add to Watchlist'}
           >
-            {inWatchlist ? (
-              <>
-                <Check className="size-4 mr-2" />
-                In Watchlist
-              </>
-            ) : (
-              <>
-                <Eye className="size-4 mr-2" />
-                Add to Watchlist
-              </>
-            )}
-          </Button>
-          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => {
+                void handleWatchlist()
+              }}
+            >
+              {inWatchlist ? (
+                <Check className="size-4" />
+              ) : (
+                <Eye className="size-4" />
+              )}
+            </Button>
+          </Tooltip>
+
+          <Tooltip content="Category for downloads">
             <Select
               value={selectedCategory}
               onChange={(val) => {
@@ -438,36 +492,42 @@ const MediaModal = ({
                   { value: 'TV Shows', label: 'TV Shows' },
                 ]
               }
-              className="w-40"
+              className="w-32"
             />
+          </Tooltip>
+
+          <Tooltip content={t('discovery.subscribe') || 'Subscribe'}>
             <Button
+              size="icon"
               onClick={() => {
                 void handleSubscribe()
               }}
               disabled={isSubmitting || !user}
             >
               {isSubmitting ? (
-                <Loader2 className="size-4 mr-2 animate-spin" />
+                <Loader2 className="size-4 animate-spin" />
               ) : (
-                <Rss className="size-4 mr-2" />
+                <Rss className="size-4" />
               )}
-              {t('discovery.subscribe') || 'Subscribe'}
             </Button>
-          </div>
-          <Button
-            variant="outline"
-            onClick={() => {
-              void handleSearchOnRutor()
-            }}
-            disabled={isSearchingLive}
-          >
-            {isSearchingLive ? (
-              <Loader2 className="size-4 mr-2 animate-spin" />
-            ) : (
-              <Search className="size-4 mr-2" />
-            )}
-            {t('discovery.search_on_rutor')}
-          </Button>
+          </Tooltip>
+
+          <Tooltip content={t('discovery.search_on_rutor')}>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => {
+                void handleSearchOnRutor()
+              }}
+              disabled={isSearchingLive}
+            >
+              {isSearchingLive ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Search className="size-4" />
+              )}
+            </Button>
+          </Tooltip>
         </div>
 
         {/* Recommendations */}

--- a/frontend/src/pages/SettingsConfig.tsx
+++ b/frontend/src/pages/SettingsConfig.tsx
@@ -33,6 +33,7 @@ export default function SettingsConfig() {
   const [telegramToken, setTelegramToken] = useState('')
   const [tmdbApiKey, setTmdbApiKey] = useState('')
   const [tmdbSessionId, setTmdbSessionId] = useState('')
+  const [torrentSortKeywords, setTorrentSortKeywords] = useState('')
 
   // Torrent Client State
   const [host, setHost] = useState('localhost')
@@ -102,6 +103,9 @@ export default function SettingsConfig() {
         setTelegramToken(String(res.current_values.telegram_token || ''))
         setTmdbApiKey(String(res.current_values.tmdb_api_key || ''))
         setTmdbSessionId(String(res.current_values.tmdb_session_id || ''))
+        setTorrentSortKeywords(
+          String(res.current_values.torrent_sort_keywords || ''),
+        )
 
         setHost(String(res.current_values.qbittorrent_host || 'localhost'))
         setPort(Number(res.current_values.qbittorrent_port || 8080))
@@ -131,6 +135,7 @@ export default function SettingsConfig() {
       },
       tmdb_api_key: tmdbApiKey,
       tmdb_session_id: tmdbSessionId,
+      torrent_sort_keywords: torrentSortKeywords,
       torrent: {
         client: 'qbittorrent',
         host,
@@ -330,6 +335,35 @@ export default function SettingsConfig() {
                 </Button>
               )}
             </div>
+          </div>
+
+          <div className="grid gap-2">
+            <div className="flex items-center gap-2">
+              <label
+                htmlFor="torrentSortKeywords"
+                className="text-sm font-medium text-zinc-400"
+              >
+                Torrent sort keywords
+              </label>
+              <Tooltip
+                content={
+                  'Comma-separated. Releases matching MORE keywords float to the top, ' +
+                  'then by seeds, then smallest size. Example: LostFilm, Кубик в Кубе, BDRip'
+                }
+              >
+                <div className="p-1 cursor-help rounded-full hover:bg-zinc-800 text-zinc-500 hover:text-zinc-300">
+                  <Info className="size-4" />
+                </div>
+              </Tooltip>
+            </div>
+            <Input
+              id="torrentSortKeywords"
+              value={torrentSortKeywords}
+              onChange={(e) => {
+                setTorrentSortKeywords(e.target.value)
+              }}
+              placeholder="LostFilm, Кубик в Кубе, BDRip"
+            />
           </div>
         </div>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -98,6 +98,15 @@ export interface TmdbMedia {
   imdb_id?: string // Shortcut or computed
   runtime?: number
   origin_country?: string[]
+  original_title?: string
+  original_name?: string
+  number_of_seasons?: number
+  number_of_episodes?: number
+  episode_run_time?: number[]
+  credits?: {
+    cast?: { id: number; name: string; character?: string; order?: number }[]
+    crew?: { id: number; name: string; job?: string; department?: string }[]
+  }
 }
 
 export interface TaskExecution {

--- a/src/telegram_rutor_bot/api/routes/discovery.py
+++ b/src/telegram_rutor_bot/api/routes/discovery.py
@@ -105,8 +105,9 @@ async def get_media_details(
     db: AsyncSession = Depends(get_async_db),
 ) -> dict[str, Any]:
     """Get full details for a movie or TV show"""
-    # Fetch details with external_ids
-    details = await tmdb.get_details(media_type, media_id, append_to_response='external_ids')
+    # Fetch details with external_ids + credits — credits power the director / cast lines
+    # the frontend modal renders alongside the rest of the TMDB info.
+    details = await tmdb.get_details(media_type, media_id, append_to_response='external_ids,credits')
 
     # Enrich with library status (single item list)
     enriched_list = await _enrich_with_library_status([details], db)
@@ -177,7 +178,9 @@ async def get_library(
     db: AsyncSession = Depends(get_async_db),
 ) -> list[dict[str, Any]]:
     """Get films in local library"""
-    stmt = select(Film).order_by(Film.id.desc()).offset(offset).limit(limit)
+    # Films without a TMDB id can't be opened in the discovery modal — its details
+    # fetch hits TMDB by the same id, and a local id collides with random TMDB rows.
+    stmt = select(Film).where(Film.tmdb_id.is_not(None)).order_by(Film.id.desc()).offset(offset).limit(limit)
 
     if media_type != 'all':
         stmt = stmt.where(Film.tmdb_media_type == media_type)
@@ -307,8 +310,8 @@ async def search_on_rutor(
     Search for torrents on Rutor by TMDB ID.
     If film doesn't exist locally, it will be created.
     """
-    if media_type != 'movie':
-        raise HTTPException(status_code=400, detail='Only movies are supported for now')
+    if media_type not in {'movie', 'tv'}:
+        raise HTTPException(status_code=400, detail='Unsupported media_type')
 
     # Check if film exists
     stmt = select(Film).where(Film.tmdb_id == media_id)
@@ -380,17 +383,22 @@ async def search_on_rutor(
 
 
 def _build_search_queries(film: Film, details: dict[str, Any]) -> set[str]:
-    queries = set()
-    query_localized = film.name
-    if film.year:
-        query_localized += f' ({film.year})'
-    queries.add(query_localized)
+    """Compose unique rutor search strings to enqueue.
+
+    Movies get `name (year)` plus the original-title variant when distinct.
+    TV releases on rutor rarely include the air-date year (it would filter out
+    every season-pack), so we drop the year for `tv` titles.
+    """
+    queries: set[str] = set()
+    is_tv = film.tmdb_media_type == 'tv'
+
+    def _with_year(base: str) -> str:
+        return f'{base} ({film.year})' if film.year and not is_tv else base
+
+    queries.add(_with_year(film.name))
 
     original_name = details.get('original_title') or details.get('original_name')
     if original_name and original_name != film.name:
-        query_original = original_name
-        if film.year:
-            query_original += f' ({film.year})'
-        queries.add(query_original)
+        queries.add(_with_year(original_name))
 
     return queries

--- a/src/telegram_rutor_bot/config.py
+++ b/src/telegram_rutor_bot/config.py
@@ -100,6 +100,12 @@ class Settings(BaseSettings):
     tmdb_session_id: str | None = Field(default=None, description='TMDB Session ID')
     tmdb_language: str = Field(default='ru-RU', description='Language for TMDB results')
 
+    # Display sort: comma-separated keywords ranked by match count, then seeds, then size
+    torrent_sort_keywords: str | None = Field(
+        default=None,
+        description='Comma-separated keywords. Releases matching more of these surface first in display lists.',
+    )
+
     # Genre to category mapping
     genre_mapping: dict[str, list[str]] = Field(
         default_factory=lambda: {

--- a/src/telegram_rutor_bot/config_listener.py
+++ b/src/telegram_rutor_bot/config_listener.py
@@ -38,6 +38,7 @@ async def refresh_settings_from_db() -> None:
                 'inactive_seeding_time_limit',
                 'tmdb_api_key',
                 'tmdb_session_id',
+                'torrent_sort_keywords',
             ]
             for field in fields_to_check:
                 val = getattr(db_config, field, None)

--- a/src/telegram_rutor_bot/db/films.py
+++ b/src/telegram_rutor_bot/db/films.py
@@ -77,20 +77,22 @@ async def get_or_create_film(
 
 
 async def get_films(
-    session: AsyncSession, limit: int = 20, query: str | None = None, category_id: int | None = None
+    session: AsyncSession, limit: int = 20, search_term: str | None = None, category_id: int | None = None
 ) -> list[Film]:
-    """Get films with optional query filter"""
-    if query:
-        # Use raw SQL for the LIKE query
-        # Note: category_id filtering not implemented for raw query mode yet as it's not used by API
-        text_stmt = text(f"""
-            SELECT DISTINCT f.* FROM films f
-            JOIN torrents t ON f.id = t.film_id
-            WHERE {query}
-            ORDER BY t.created DESC
+    """Get films with optional name-substring filter (case-insensitive)."""
+    if search_term:
+        text_stmt = text("""
+            SELECT f.* FROM films f
+            JOIN (
+                SELECT film_id, MAX(created) AS last_created
+                FROM torrents
+                GROUP BY film_id
+            ) t ON f.id = t.film_id
+            WHERE LOWER(f.name) LIKE LOWER(:pattern)
+            ORDER BY t.last_created DESC
             LIMIT :limit
         """)
-        result = await session.execute(text_stmt, {'limit': limit})
+        result = await session.execute(text_stmt, {'pattern': f'%{search_term}%', 'limit': limit})
         return [Film(**row) for row in result.mappings()]
 
     # Simple query for recent films

--- a/src/telegram_rutor_bot/db/models.py
+++ b/src/telegram_rutor_bot/db/models.py
@@ -228,6 +228,7 @@ class AppConfigUpdate(TypedDict, total=False):
     tmdb_session_id: str | None
     search_quality_filters: str | None
     search_translation_filters: str | None
+    torrent_sort_keywords: str | None
     seed_ratio_limit: float
     seed_time_limit: int
     inactive_seeding_time_limit: int
@@ -270,6 +271,9 @@ class AppConfig(Base):
     # Search Filters
     search_quality_filters: Mapped[str | None] = mapped_column(String, nullable=True)
     search_translation_filters: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    # Display sort: comma-separated keywords; releases matching more of these float to the top
+    torrent_sort_keywords: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # Seed limits
     seed_ratio_limit: Mapped[float] = mapped_column(Float, default=1.0)

--- a/src/telegram_rutor_bot/handlers/__init__.py
+++ b/src/telegram_rutor_bot/handlers/__init__.py
@@ -8,6 +8,7 @@ from .commons import (
     start,
     unknown,
 )
+from .discovery import discovery_callback_handler, discovery_command, discovery_season_callback_handler
 from .search import search_callback_handler, search_delete, search_execute, search_list
 from .subscribe import subscribe, subscriptions_list, unsubscribe
 from .torrents import (
@@ -25,6 +26,9 @@ from .watchlist import watch_command
 __all__ = [
     'add_user_cmd',
     'callback_query_handler',
+    'discovery_callback_handler',
+    'discovery_command',
+    'discovery_season_callback_handler',
     'download_torrent',
     'help_handler',
     'language_handler',

--- a/src/telegram_rutor_bot/handlers/discovery.py
+++ b/src/telegram_rutor_bot/handlers/discovery.py
@@ -1,0 +1,476 @@
+"""Discovery (TMDB) Telegram bot command handlers"""
+
+import asyncio
+import contextlib
+import html
+import logging
+from typing import Any
+
+from sqlalchemy import select
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram import error as telegram_error
+from telegram.constants import ParseMode
+from telegram.ext import ContextTypes
+
+from telegram_rutor_bot.clients.tmdb import TmdbClient
+from telegram_rutor_bot.db import (
+    get_async_session,
+    get_or_create_film,
+    get_torrents_by_film,
+    get_user_by_chat,
+    update_film_metadata,
+)
+from telegram_rutor_bot.db.models import Film
+from telegram_rutor_bot.helpers import build_tmdb_caption, format_films
+from telegram_rutor_bot.tasks.jobs import search_film_on_rutor
+from telegram_rutor_bot.utils import DEFAULT_LANGUAGE, get_text, security, send_notifications
+
+__all__ = (
+    'discovery_callback_handler',
+    'discovery_command',
+    'discovery_season_callback_handler',
+)
+
+log = logging.getLogger(__name__)
+
+_MAX_RESULTS: int = 5
+_CALLBACK_PREFIX: str = 'disc_rutor:'
+_SEASON_PICKER_PREFIX: str = 'disc_season:'
+_SEASONS_PER_ROW: int = 4
+_MAX_SEASONS_BUTTONS: int = 24  # Telegram caps inline keyboards at 100; keep it sane.
+
+tmdb = TmdbClient()
+
+
+async def _get_lang(update: Update) -> str:
+    """Resolve UI language from the user record (fallback to default)."""
+    chat_id = update.effective_chat.id if update.effective_chat else 0
+    if not chat_id:
+        return DEFAULT_LANGUAGE
+    async with get_async_session() as session:
+        user = await get_user_by_chat(session, chat_id)
+        return user.language if user else DEFAULT_LANGUAGE
+
+
+def _extract_title(item: dict[str, Any]) -> str:
+    """Pick the best human-readable title from a TMDB item."""
+    title = item.get('title') or item.get('name') or item.get('original_title') or item.get('original_name')
+    if not title:
+        return 'Unknown'
+    return str(title)
+
+
+def _extract_year(item: dict[str, Any]) -> int | None:
+    """Extract a release/first-air year from a TMDB item, if present."""
+    raw_date = item.get('release_date') or item.get('first_air_date')
+    if not raw_date:
+        return None
+    try:
+        return int(str(raw_date)[:4])
+    except (ValueError, TypeError):
+        return None
+
+
+def _filter_results(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop TMDB items missing the keys we need to act on."""
+    filtered: list[dict[str, Any]] = []
+    for item in results:
+        if not item.get('id'):
+            continue
+        media_type = item.get('media_type')
+        if media_type not in ('movie', 'tv'):
+            continue
+        filtered.append(item)
+    return filtered
+
+
+def _parse_callback_data(data: str) -> tuple[str, int, int | None] | None:
+    """Parse `disc_rutor:<media_type>:<media_id>[:<season>]`.
+
+    Optional 3rd segment is a season number (0 = all-seasons sentinel for tv).
+    Returns None on malformed input.
+    """
+    if not data.startswith(_CALLBACK_PREFIX):
+        return None
+    payload = data[len(_CALLBACK_PREFIX) :]
+    parts = payload.split(':')
+    if len(parts) < 2 or len(parts) > 3:
+        return None
+    media_type, raw_id = parts[0], parts[1]
+    if not media_type or not raw_id:
+        return None
+    try:
+        media_id = int(raw_id)
+    except ValueError:
+        return None
+    season: int | None = None
+    if len(parts) == 3:
+        try:
+            season_int = int(parts[2])
+        except ValueError:
+            return None
+        season = season_int if season_int > 0 else None  # 0 = all-seasons sentinel
+    return media_type, media_id, season
+
+
+def _parse_season_callback_data(data: str) -> int | None:
+    """Parse `disc_season:<media_id>`; only used for the season-picker entry button."""
+    if not data.startswith(_SEASON_PICKER_PREFIX):
+        return None
+    raw = data[len(_SEASON_PICKER_PREFIX) :]
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _build_search_query(
+    name: str,
+    year: int | None,
+    original_title: str | None,
+    *,
+    is_tv: bool = False,
+    season: int | None = None,
+) -> str:
+    """Compose the rutor search string.
+
+    Prefer the original (English/source-language) title — old foreign films are usually
+    indexed on rutor under their original name; the localized name often misses releases.
+    Fall back to `name` when the original is missing or identical.
+
+    For TV we drop the year — TMDB's `first_air_date` year rarely appears in season /
+    episode release names, so including it is more likely to filter out matches than help.
+    A specific season (`S01`) is appended when requested by the picker.
+    """
+    base = (
+        original_title.strip() if original_title and original_title.strip() and original_title.strip() != name else name
+    )
+    if season:
+        return f'{base} S{season:02d}'
+    if year and not is_tv:
+        return f'{base} {year}'
+    return base
+
+
+@security()
+async def discovery_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle `/discovery <название>` — search TMDB and offer rutor parsing."""
+    assert update.message is not None  # security() guarantees a message
+    assert update.effective_chat is not None
+    assert update.message.text is not None
+
+    lang = await _get_lang(update)
+    query = update.message.text.replace('/discovery', '', 1).strip()
+
+    if not query:
+        await context.bot.send_message(chat_id=update.effective_chat.id, text=get_text('discovery_usage', lang))
+        return
+
+    try:
+        raw_results = await tmdb.search_multi(query)
+    except Exception as e:
+        # Catching broadly here because TmdbClient internals already swallow httpx errors,
+        # so a leak here usually means an unexpected client/runtime issue we want logged.
+        log.exception('TMDB search_multi failed for query %r: %s', query, e)
+        await context.bot.send_message(chat_id=update.effective_chat.id, text=get_text('discovery_tmdb_error', lang))
+        return
+
+    results = _filter_results(raw_results)[:_MAX_RESULTS]
+    if not results:
+        await context.bot.send_message(chat_id=update.effective_chat.id, text=get_text('discovery_no_results', lang))
+        return
+
+    # Optional header so the user sees something while detail fetches run in parallel.
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text=get_text('discovery_results_header', lang),
+        parse_mode=ParseMode.HTML,
+    )
+
+    # Parallel-fetch full details with credits for each pick — gives us director, cast,
+    # runtime, genres list, and country names in one shot per result.
+    detail_tasks = [_safe_get_details(item['media_type'], item['id']) for item in results]
+    details_list = await asyncio.gather(*detail_tasks)
+
+    for item, details in zip(results, details_list, strict=True):
+        await _send_pick_card(context, update.effective_chat.id, item, details, lang)
+
+
+async def _safe_get_details(media_type: str, media_id: int) -> dict[str, Any]:
+    """Best-effort TMDB details fetch — empty dict on any error so the picker can degrade."""
+    try:
+        return await tmdb.get_details(media_type, media_id, append_to_response='credits')
+    except Exception as e:
+        log.debug('TMDB get_details failed for %s/%s: %s', media_type, media_id, e)
+        return {}
+
+
+async def _send_pick_card(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    item: dict[str, Any],
+    details: dict[str, Any],
+    lang: str,
+) -> None:
+    """Send one TMDB result as its own message — photo + caption + 'pick' button."""
+    name = _extract_title({**item, **details})
+    year = _extract_year({**item, **details})
+    original_title = (
+        details.get('original_title')
+        or details.get('original_name')
+        or item.get('original_title')
+        or item.get('original_name')
+    )
+
+    caption = build_tmdb_caption(
+        name=name,
+        year=year,
+        original_title=original_title,
+        details=details or item,  # search_multi result is enough for a basic card if details fetch failed
+    )
+    if len(caption) > 1000:
+        caption = caption[:997] + '…'
+
+    media_type = item['media_type']
+    media_id = int(item['id'])
+    if media_type == 'tv':
+        # TV: show the season picker first; lets the user narrow rutor search to one season.
+        button = InlineKeyboardButton(
+            get_text('btn_discovery_pick_seasons', lang),
+            callback_data=f'{_SEASON_PICKER_PREFIX}{media_id}',
+        )
+    else:
+        button = InlineKeyboardButton(
+            get_text('btn_discovery_pick_torrents', lang),
+            callback_data=f'{_CALLBACK_PREFIX}{media_type}:{media_id}',
+        )
+    markup = InlineKeyboardMarkup([[button]])
+
+    poster_path = details.get('poster_path') or item.get('poster_path')
+    poster_url = f'https://image.tmdb.org/t/p/w500{poster_path}' if poster_path else None
+
+    if poster_url:
+        with contextlib.suppress(telegram_error.TelegramError):
+            await context.bot.send_photo(
+                chat_id=chat_id,
+                photo=poster_url,
+                caption=caption,
+                parse_mode=ParseMode.HTML,
+                reply_markup=markup,
+            )
+            return
+
+    # Fallback to plain text when we have no poster (or send_photo failed).
+    await context.bot.send_message(
+        chat_id=chat_id,
+        text=caption,
+        parse_mode=ParseMode.HTML,
+        disable_web_page_preview=True,
+        reply_markup=markup,
+    )
+
+
+@security()
+async def discovery_callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the user's pick from `/discovery` results — kick off rutor parse."""
+    callback_query = update.callback_query
+    if not callback_query or not callback_query.data:
+        return
+    if not update.effective_chat:
+        return
+
+    lang = await _get_lang(update)
+    parsed = _parse_callback_data(callback_query.data)
+    if parsed is None:
+        await callback_query.answer()
+        return
+
+    media_type, media_id, season = parsed
+    await callback_query.answer()
+
+    film, display_name, display_year, original_title = await _ensure_film_for_tmdb(media_type, media_id)
+    if film is None:
+        await context.bot.send_message(chat_id=update.effective_chat.id, text=get_text('discovery_tmdb_error', lang))
+        return
+
+    chat_id = update.effective_chat.id
+    safe_title = html.escape(display_name)
+    year_str = str(display_year) if display_year else '—'
+
+    async with get_async_session() as session:
+        existing_torrents = await get_torrents_by_film(session, film.id)
+
+    # Filter DB hits to the requested season when the user picked one — the parser
+    # already records `Torrent.season` from `S01E02` markers (commit 725a5f7).
+    if season is not None:
+        existing_torrents = [t for t in existing_torrents if (t.season or 0) == season]
+
+    if existing_torrents:
+        # DB has the film + torrents — show what we have, skip the rutor refresh.
+        notifications = await format_films([film])
+        await send_notifications(context.bot, chat_id, notifications)
+        confirmation = get_text(
+            'discovery_existing_from_db',
+            lang,
+            title=safe_title,
+            year=year_str,
+            count=len(existing_torrents),
+        )
+    else:
+        # Nothing yet for this film/season — go to rutor and notify when the worker finishes.
+        confirmation = get_text('discovery_search_started', lang, title=safe_title, year=year_str)
+        search_query = _build_search_query(
+            display_name,
+            display_year,
+            original_title,
+            is_tv=(media_type == 'tv'),
+            season=season,
+        )
+        await search_film_on_rutor.kiq(film.id, search_query, requester_chat_id=chat_id)
+
+    # Prefer editing the picker message so the user sees their choice was registered;
+    # fall back to a fresh message if Telegram refuses the edit.
+    edited = False
+    with contextlib.suppress(telegram_error.TelegramError):
+        await callback_query.edit_message_text(text=confirmation, parse_mode=ParseMode.HTML)
+        edited = True
+
+    if not edited:
+        await context.bot.send_message(chat_id=chat_id, text=confirmation, parse_mode=ParseMode.HTML)
+
+
+@security()
+async def discovery_season_callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Replace the TV pick card's keyboard with one button per season + 'all seasons'."""
+    callback_query = update.callback_query
+    if not callback_query or not callback_query.data:
+        return
+    if not update.effective_chat:
+        return
+
+    lang = await _get_lang(update)
+    media_id = _parse_season_callback_data(callback_query.data)
+    if media_id is None:
+        await callback_query.answer()
+        return
+    await callback_query.answer()
+
+    details = await _safe_get_details('tv', media_id)
+    season_numbers = _extract_season_numbers(details)
+
+    buttons: list[list[InlineKeyboardButton]] = []
+    # "All seasons" first — fast path for users who don't care about season filter.
+    buttons.append(
+        [
+            InlineKeyboardButton(
+                get_text('btn_discovery_all_seasons', lang),
+                callback_data=f'{_CALLBACK_PREFIX}tv:{media_id}:0',
+            )
+        ]
+    )
+
+    row: list[InlineKeyboardButton] = []
+    for season_n in season_numbers[:_MAX_SEASONS_BUTTONS]:
+        row.append(
+            InlineKeyboardButton(
+                get_text('btn_discovery_season', lang, n=season_n),
+                callback_data=f'{_CALLBACK_PREFIX}tv:{media_id}:{season_n}',
+            )
+        )
+        if len(row) == _SEASONS_PER_ROW:
+            buttons.append(row)
+            row = []
+    if row:
+        buttons.append(row)
+
+    markup = InlineKeyboardMarkup(buttons)
+
+    # Edit only the keyboard so the photo + caption from the pick card stay in place.
+    with contextlib.suppress(telegram_error.TelegramError):
+        await callback_query.edit_message_reply_markup(reply_markup=markup)
+
+
+def _extract_season_numbers(details: dict[str, Any]) -> list[int]:
+    """Pull non-special season numbers from TMDB tv details (skips season 0 / Specials)."""
+    seasons = details.get('seasons') or []
+    numbers: list[int] = []
+    for s in seasons:
+        if not isinstance(s, dict):
+            continue
+        n = s.get('season_number')
+        if isinstance(n, int) and n >= 1:
+            numbers.append(n)
+    if not numbers:
+        # Fallback: TMDB sometimes only exposes `number_of_seasons` (e.g. degraded response)
+        total = details.get('number_of_seasons')
+        if isinstance(total, int) and total >= 1:
+            numbers = list(range(1, total + 1))
+    return sorted(numbers)
+
+
+async def _ensure_film_for_tmdb(media_type: str, media_id: int) -> tuple[Film | None, str, int | None, str | None]:
+    """Look up or create a Film row for the TMDB id; return (film, name, year, original_title)."""
+    async with get_async_session() as session:
+        existing = (await session.execute(select(Film).where(Film.tmdb_id == media_id))).scalar_one_or_none()
+
+        details: dict[str, Any] = {}
+        try:
+            details = await tmdb.get_details(media_type, media_id)
+        except Exception as e:
+            # TmdbClient already returns {} on httpx errors, but a transport-level
+            # exception bubbling up here means we still want a row if we have one.
+            log.warning('TMDB get_details failed for %s/%s: %s', media_type, media_id, e)
+
+        details_original = details.get('original_title') or details.get('original_name')
+
+        if existing:
+            year = existing.year if existing.year else _extract_year(details)
+            display_name = existing.name or _extract_title(details)
+            return existing, display_name, year, existing.original_title or details_original
+
+        if not details:
+            return None, '', None, None
+
+        name = _extract_title(details)
+        year = _extract_year(details)
+        original_title = details_original
+
+        country: str | None = None
+        production_countries = details.get('production_countries') or []
+        if production_countries:
+            first_country = production_countries[0]
+            if isinstance(first_country, dict):
+                country = first_country.get('name')
+
+        rating_raw = details.get('vote_average')
+        rating: float | None = None
+        if rating_raw is not None:
+            try:
+                rating = float(rating_raw)
+            except (TypeError, ValueError):
+                rating = None
+
+        dummy_blake = f'tmdb_{media_type}_{media_id}'
+        film = await get_or_create_film(
+            session,
+            blake=dummy_blake,
+            year=year,
+            name=name,
+            poster=details.get('poster_path'),
+            rating=rating,
+            original_title=original_title,
+            country=country,
+        )
+        await update_film_metadata(
+            session,
+            film_id=film.id,
+            tmdb_id=media_id,
+            tmdb_media_type=media_type,
+            year=year,
+            name=name,
+            poster=details.get('poster_path'),
+            rating=rating,
+            original_title=original_title,
+            country=country,
+        )
+        return film, name, year, original_title

--- a/src/telegram_rutor_bot/handlers/torrents.py
+++ b/src/telegram_rutor_bot/handlers/torrents.py
@@ -315,7 +315,7 @@ async def _handle_text_search(update: Update, context: ContextTypes.DEFAULT_TYPE
     """Handle standard text search"""
     assert update.effective_chat is not None
     async with get_async_session() as session:
-        films = await get_films(session, limit=20, query=f"LOWER(f.name) LIKE LOWER('%{search}%')")
+        films = await get_films(session, limit=20, search_term=search)
 
     notifications = await format_films(films)
 

--- a/src/telegram_rutor_bot/helpers.py
+++ b/src/telegram_rutor_bot/helpers.py
@@ -10,10 +10,15 @@ from urllib.parse import urljoin
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
+from telegram_rutor_bot.clients.tmdb import TmdbClient
+from telegram_rutor_bot.config import settings
 from telegram_rutor_bot.db import get_async_session, get_torrents_by_film, update_film_metadata
 from telegram_rutor_bot.rutor import get_torrent_info
 from telegram_rutor_bot.rutor.constants import RUTOR_BASE_URL
 from telegram_rutor_bot.schemas import Notification
+
+_tmdb = TmdbClient()
+_CAST_LIMIT = 5
 
 log = logging.getLogger(__name__)
 
@@ -37,120 +42,389 @@ def humanize_bytes(num: float, suffix: str = 'B') -> str:
     return f'{num:.1f} Y{suffix}'
 
 
-def _extract_movie_info_lines(film_info: str) -> list[str]:
-    """Extract movie info lines before technical details section"""
-    info_lines = film_info.split('\n')
-    movie_info_lines = []
-
-    for line in info_lines:
-        if '📀 Технические детали:' in line:
-            break
-        if line.strip():
-            movie_info_lines.append(line)
-
-    return movie_info_lines
+_YEAR_PREFIX_RE = re.compile(r'^.*?\((19|20)\d{2}(?:[‐-―\-]\d{2,4})?\)\s*')
 
 
 def _clean_torrent_name(torrent_name: str, film_name: str, film_year: int) -> str:
-    """Clean torrent name by removing film name and year"""
-    # Remove film name and year in various formats
-    clean_name = re.sub(rf'^.*\s\({film_year}\)\s', '', torrent_name)
-    clean_name = re.sub(rf'^{re.escape(film_name)}\s*\({film_year}\)\s*', '', clean_name)
-    return re.sub(rf'^{re.escape(film_name)}\s+{film_year}\s+', '', clean_name)
+    """Strip the localized + original title and any `(YYYY)` / `(YYYY-YYYY)` prefix.
+
+    Most rutor releases follow the pattern
+        `<RU title> / <Original title> (<year>[-<end_year>]) <release info>`
+    so the cheapest cleanup is to drop everything up to and including the first year
+    parenthesis. The legacy regexes below handle the rare cases where the year is
+    missing entirely (e.g. cartoons indexed without a release year).
+    """
+    cleaned = _YEAR_PREFIX_RE.sub('', torrent_name).strip()
+    if cleaned and cleaned != torrent_name:
+        return cleaned
+    # Fallback — torrent without parenthesized year. Strip film name + year tokens directly.
+    cleaned = re.sub(rf'^{re.escape(film_name)}\s*\({film_year}\)\s*', '', torrent_name)
+    return re.sub(rf'^{re.escape(film_name)}\s+{film_year}\s+', '', cleaned).strip()
 
 
-def _format_torrents_buttons(
-    torrents: list[Any], film: Film, metadata: dict[str, Any] | None = None
-) -> InlineKeyboardMarkup:
-    """Format list of torrents as inline buttons"""
-    buttons = []
+def _sort_keywords() -> list[str]:
+    """Pull case-folded keywords from `settings.torrent_sort_keywords`.
 
-    for t in torrents:
-        clean_name = _clean_torrent_name(t.name, film.name, film.year)
-        # Truncate clean_name if too long for button
-        if len(clean_name) > 30:
-            clean_name = clean_name[:27] + '...'
+    Comma-separated string, surrounding whitespace stripped, empty entries dropped.
+    Lower-cased once here so the per-torrent scorer doesn't repeat the work.
+    """
+    raw = getattr(settings, 'torrent_sort_keywords', None) or ''
+    return [k.strip().lower() for k in raw.split(',') if k.strip()]
 
-        size = humanize_bytes(t.size)
-        # Text: "↓ 1080p (10.5 GB)"
-        text = f'⬇️ {clean_name} ({size})'
 
-        row = [InlineKeyboardButton(text, callback_data=f'dl_{t.id}')]
+def _keyword_match_count(name: str, keywords: list[str]) -> int:
+    """Substring match count, case-insensitive. `keywords` must already be lower-cased."""
+    if not keywords or not name:
+        return 0
+    lowered = name.lower()
+    return sum(1 for kw in keywords if kw in lowered)
 
-        # Add Rutor button
+
+def _sorted_torrents(torrents: list[Any], film: Film | None = None) -> list[Any]:
+    """Sort torrents for display.
+
+    Primary axis (configurable, applied within season/episode for tv):
+      1. **Keyword match count** (descending) — `settings.torrent_sort_keywords`
+         lets the user prefer specific release groups, voice studios, quality tokens.
+      2. **Seeds** (descending).
+      3. **Size** (ascending — smaller is faster to fetch).
+
+    For tv, `(season, episode)` stays as the outer key so the natural sequence is
+    preserved; multi-season packs (no parsed `season`) sink to the end via `inf`.
+    With no keywords configured, the seeds/size triple still kicks in — meaning
+    seedier and smaller releases now win ties (older behaviour was size-first only).
+    """
+    keywords = _sort_keywords()
+
+    def _quality_key(t: Any) -> tuple[int, int, int]:  # noqa: ANN401 - SQLAlchemy Torrent row, attribute-based access
+        # Negate "more is better" axes so Python's ascending sort puts them first.
+        score = _keyword_match_count(getattr(t, 'name', '') or '', keywords)
+        seeds = getattr(t, 'seeds', None) or 0
+        size = getattr(t, 'sz', 0) or 0
+        return (-score, -seeds, size)
+
+    is_tv = bool(film and getattr(film, 'tmdb_media_type', None) == 'tv')
+    if is_tv:
+        return sorted(
+            torrents,
+            key=lambda t: (
+                getattr(t, 'season', None) or float('inf'),
+                getattr(t, 'episode', None) or 0,
+                *_quality_key(t),
+            ),
+        )
+    return sorted(torrents, key=_quality_key)
+
+
+def _episode_tag(t: Any) -> str:  # noqa: ANN401 - SQLAlchemy Torrent row, attribute-based access
+    """`S01E02` / `S01` / `` based on what the parser stored on the torrent."""
+    season = getattr(t, 'season', None)
+    episode = getattr(t, 'episode', None)
+    if season and episode:
+        return f'S{int(season):02d}E{int(episode):02d}'
+    if season:
+        return f'S{int(season):02d}'
+    return ''
+
+
+_NUM_BUTTON_EMOJI = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', '🔟']
+_BUTTONS_PER_ROW = 2
+
+
+def _format_torrents_lines(torrents: list[Any], film: Film) -> str:
+    """Render a numbered list of releases — one HTML line per torrent.
+
+    Each line is `<numeric_emoji> <a href="rutor_url">size · seeds · tag · release</a>`.
+    The HTML anchor doesn't truncate (unlike inline-button labels), so the full
+    distinguishing info stays visible AND tappable to open rutor.
+    """
+    sorted_t = _sorted_torrents(torrents, film)
+    if not sorted_t:
+        return ''
+
+    lines: list[str] = ['📥 <b>Раздачи:</b>']
+    for idx, t in enumerate(sorted_t):
+        prefix = _NUM_BUTTON_EMOJI[idx] if idx < len(_NUM_BUTTON_EMOJI) else f'{idx + 1}.'
+        size = humanize_bytes(t.size).replace(' ', '')
+        seeds_value = getattr(t, 'seeds', None)
+        bits: list[str] = [size]
+        if seeds_value is not None:
+            bits.append(f'🌱{seeds_value}')
+        tag = _episode_tag(t)
+        if tag:
+            bits.append(tag)
+        clean = _clean_torrent_name(t.name, film.name, film.year).strip()
+        clean = clean.replace('1080p ', '').replace(' 1080p', '').strip()
+        if clean:
+            bits.append(clean)
+
+        body = ' · '.join(bits)
         rutor_url = urljoin(RUTOR_BASE_URL, t.link)
-        row.append(InlineKeyboardButton('🔗', url=rutor_url))
+        link = f'<a href="{html.escape(rutor_url, quote=True)}">{html.escape(body)}</a>'
+        lines.append(f'{prefix} {link}')
 
+    return '\n'.join(lines)
+
+
+def _format_torrents_buttons(torrents: list[Any], film: Film) -> InlineKeyboardMarkup:
+    """Number + size + seeds on each button — paired with the per-line list in caption.
+
+    Layout per button: `{number_emoji} {size} 🌱{seeds}` (e.g. `1️⃣ 14.7GB 🌱29`).
+    Two per row keeps each button wide enough that the size and seed count survive
+    Telegram's per-button truncation on narrow phones.
+    """
+    sorted_torrents = _sorted_torrents(torrents, film)
+    buttons: list[list[InlineKeyboardButton]] = []
+    row: list[InlineKeyboardButton] = []
+    for idx, t in enumerate(sorted_torrents):
+        num = _NUM_BUTTON_EMOJI[idx] if idx < len(_NUM_BUTTON_EMOJI) else f'{idx + 1}'
+        size = humanize_bytes(t.size).replace(' ', '')
+        seeds_value = getattr(t, 'seeds', None)
+        seeds_part = f' 🌱{seeds_value}' if seeds_value is not None else ''
+        label = f'{num} {size}{seeds_part}'
+        row.append(InlineKeyboardButton(label, callback_data=f'dl_{t.id}'))
+        if len(row) == _BUTTONS_PER_ROW:
+            buttons.append(row)
+            row = []
+    if row:
         buttons.append(row)
-
-    # Add IMDB/KP buttons if metadata exists
-    if metadata:
-        info_row = []
-        if metadata.get('imdb_url'):
-            info_row.append(InlineKeyboardButton('⭐ IMDB', url=metadata['imdb_url']))
-        if metadata.get('kp_url'):
-            info_row.append(InlineKeyboardButton('🎬 KP', url=metadata['kp_url']))
-
-        if info_row:
-            buttons.append(info_row)
-
     return InlineKeyboardMarkup(buttons)
 
 
-async def _format_film_with_details(session: AsyncSession, film: Film, torrents: list[Any]) -> Notification:
-    """Format film with detailed info from first torrent returning structured data"""
-    first_torrent = torrents[0]
-
+async def _fetch_tmdb_details(film: Film) -> dict[str, Any]:
+    """Best-effort live TMDB details fetch with credits — empty dict on any error."""
+    if not film.tmdb_id:
+        return {}
+    media_type = film.tmdb_media_type or 'movie'
     try:
-        film_info, poster, _, poster_url, metadata = await get_torrent_info(first_torrent.link)
+        return await _tmdb.get_details(media_type, film.tmdb_id, append_to_response='credits')
+    except Exception as e:
+        # We log at debug because every rendered card hits TMDB; transport hiccups
+        # shouldn't spam warnings while users are browsing.
+        log.debug('TMDB details fetch failed for film %s: %s', film.id, e)
+        return {}
 
-        # Update film poster if available and missing
-        if poster_url and not film.poster:
-            await update_film_metadata(session, film.id, poster=poster_url)
 
-        # Extract movie info lines
-        movie_info_lines = _extract_movie_info_lines(film_info)
+def _format_runtime(minutes: int | None) -> str | None:
+    """Render TMDB runtime (minutes) as `Xh Ymin` (e.g. 87 → `1ч 27мин`)."""
+    if not minutes or minutes <= 0:
+        return None
+    hours, mins = divmod(minutes, 60)
+    if hours and mins:
+        return f'{hours}ч {mins:02d}мин'
+    if hours:
+        return f'{hours}ч'
+    return f'{mins}мин'
 
-        # Build caption
-        # Title in bold (HTML)
-        safe_name = html.escape(film.name)
-        caption_lines = [f'🎬 <b>{safe_name}</b> ({film.year})']
 
-        # We should also escape movie_info_lines just in case they contain < or >
-        safe_info_lines = [html.escape(line) for line in movie_info_lines]
-        caption_lines.extend(safe_info_lines)
+def _runtime_from_details(details: dict[str, Any]) -> int | None:
+    """TMDB stores `runtime` for movies (single int) and `episode_run_time` for tv (list[int])."""
+    runtime = details.get('runtime')
+    if isinstance(runtime, int) and runtime > 0:
+        return runtime
+    ep_runs = details.get('episode_run_time')
+    if isinstance(ep_runs, list) and ep_runs and isinstance(ep_runs[0], int):
+        return ep_runs[0]
+    return None
 
-        caption = '\n'.join(caption_lines)
 
-        # Truncate caption if too long (Telegram limit 1024)
-        if len(caption) > 1000:
-            caption = caption[:997] + '...'
+def _genres_from_details(details: dict[str, Any]) -> str:
+    items = details.get('genres') or []
+    names = [g.get('name', '').strip() for g in items if isinstance(g, dict)]
+    return ', '.join(n for n in names if n)
 
-        markup = _format_torrents_buttons(torrents, film, metadata)
 
-        return {
-            'type': 'photo' if (poster or poster_url) else 'text',
-            'media': poster or poster_url,
+def _countries_from_details(details: dict[str, Any]) -> str:
+    items = details.get('production_countries') or []
+    names = [c.get('name', '').strip() for c in items if isinstance(c, dict)]
+    return ', '.join(n for n in names if n)
+
+
+def _director_from_details(details: dict[str, Any]) -> str:
+    crew = (details.get('credits') or {}).get('crew') or []
+    directors = [c.get('name', '').strip() for c in crew if isinstance(c, dict) and c.get('job') == 'Director']
+    return ', '.join(n for n in directors if n)
+
+
+def _cast_from_details(details: dict[str, Any], limit: int = _CAST_LIMIT) -> str:
+    cast = (details.get('credits') or {}).get('cast') or []
+    names = [c.get('name', '').strip() for c in cast[:limit] if isinstance(c, dict)]
+    return ', '.join(n for n in names if n)
+
+
+def _seasons_line_from_details(details: dict[str, Any]) -> str | None:
+    """Return `📺 Сезонов: N, серий: M` for tv shows, or None for movies / when absent."""
+    seasons = details.get('number_of_seasons')
+    if not isinstance(seasons, int) or seasons <= 0:
+        return None
+    episodes = details.get('number_of_episodes')
+    if isinstance(episodes, int) and episodes > 0:
+        return f'📺 Сезонов: {seasons}, серий: {episodes}'
+    return f'📺 Сезонов: {seasons}'
+
+
+def build_tmdb_caption(  # noqa: PLR0912 - composes a single multi-section caption; splitting reduces clarity
+    name: str,
+    year: int | None,
+    original_title: str | None,
+    details: dict[str, Any] | None,
+    *,
+    kp_rating: float | None = None,
+    fallback_tmdb_rating: str | float | None = None,
+    fallback_genres: str | None = None,
+    fallback_country: str | None = None,
+) -> str:
+    """Build the canonical film caption from TMDB details (or partial search data).
+
+    `details` may be either a /movie/{id} or /tv/{id} response (with optional
+    `credits` appended) OR a single result dict from /search/multi — extractors
+    treat both shapes the same and degrade gracefully on missing keys.
+
+    Used by:
+      - `_build_film_caption` (Film row + TMDB details, library/notification path)
+      - `discovery.handlers` per-pick card (TMDB details only)
+    """
+    details = details or {}
+    lines: list[str] = []
+
+    safe_name = html.escape(name)
+    year_part = f' ({year})' if year else ''
+    lines.append(f'🎬 <b>{safe_name}</b>{year_part}')
+    detail_original = (details.get('original_title') or details.get('original_name') or '').strip()
+    chosen_original = detail_original or (original_title or '').strip()
+    if chosen_original and chosen_original != name:
+        lines.append(f'🌍 <i>{html.escape(chosen_original)}</i>')
+
+    rating_bits: list[str] = []
+    tmdb_rating = _parse_rating(details.get('vote_average'))
+    if tmdb_rating is None:
+        tmdb_rating = _parse_rating(fallback_tmdb_rating)
+    if tmdb_rating is not None:
+        rating_bits.append(f'⭐ TMDB {tmdb_rating:.1f}/10')
+    if kp_rating is not None:
+        rating_bits.append(f'⭐ Кинопоиск {kp_rating:.1f}/10')
+    if rating_bits:
+        lines.append(' | '.join(rating_bits))
+
+    genres = _genres_from_details(details) or (fallback_genres or '').strip()
+    if genres:
+        lines.append(f'📁 Жанр: {html.escape(genres)}')
+
+    country = _countries_from_details(details) or (fallback_country or '').strip()
+    if country:
+        lines.append(f'🌍 Страна: {html.escape(country)}')
+
+    runtime_str = _format_runtime(_runtime_from_details(details))
+    if runtime_str:
+        lines.append(f'⏱ Продолжительность: {runtime_str}')
+
+    seasons_line = _seasons_line_from_details(details)
+    if seasons_line:
+        lines.append(seasons_line)
+
+    # Description before cast/crew so it always survives the 1000-char caption budget.
+    overview = (details.get('overview') or '').strip()
+    if overview:
+        if len(overview) > 400:
+            overview = overview[:397] + '…'
+        lines.append('')
+        lines.append(html.escape(overview))
+        lines.append('')
+
+    director = _director_from_details(details)
+    if director:
+        lines.append(f'🎭 Режиссёр: {html.escape(director)}')
+
+    cast = _cast_from_details(details)
+    if cast:
+        lines.append(f'👥 В ролях: {html.escape(cast)}')
+
+    return '\n'.join(lines)
+
+
+def _build_film_caption(film: Film, details: dict[str, Any] | None = None) -> str:
+    """Wrapper over `build_tmdb_caption` that pulls fallbacks from the Film row."""
+    return build_tmdb_caption(
+        name=film.name,
+        year=film.year,
+        original_title=film.original_title,
+        details=details,
+        kp_rating=film.kp_rating,
+        fallback_tmdb_rating=film.rating,
+        fallback_genres=film.genres,
+        fallback_country=film.country,
+    )
+
+
+async def _format_film_card(session: AsyncSession, film: Film, torrents: list[Any]) -> list[Notification]:
+    """Render a film as two messages: poster + TMDB info, then the releases list.
+
+    Splitting frees us from the 1024-char photo-caption budget: the full TMDB blurb
+    fits in the first message, and the torrents list (HTML links + numbered download
+    buttons) lives in a second text message with the much larger 4096-char budget.
+
+    Rutor torrent page is touched only when the Film row has no poster — the fetched
+    URL gets persisted via `update_film_metadata` so subsequent cards skip the round-trip.
+    """
+    details = await _fetch_tmdb_details(film)
+
+    poster_bytes: bytes | None = None
+    if torrents and not film.poster:
+        try:
+            _info, poster_bytes, _images, fetched_poster_url, _meta = await get_torrent_info(torrents[0].link)
+            if fetched_poster_url:
+                await update_film_metadata(session, film.id, poster=fetched_poster_url)
+        except (OSError, ValueError) as e:
+            log.debug('Rutor poster enrichment failed: %s', e)
+
+    caption = _build_film_caption(film, details)
+    if len(caption) > 1000:
+        caption = caption[:997] + '…'
+
+    # Prefer TMDB poster path when present — cleaner than the rutor mirror.
+    tmdb_poster = details.get('poster_path')
+    tmdb_poster_url = f'https://image.tmdb.org/t/p/w500{tmdb_poster}' if tmdb_poster else None
+    media: bytes | str | None = poster_bytes or tmdb_poster_url or film.poster
+    has_media = bool(media)
+
+    notifications: list[Notification] = [
+        {
+            'type': 'photo' if has_media else 'text',
+            'media': media if has_media else None,
             'caption': caption,
-            'reply_markup': markup,
+            'reply_markup': None,
         }
+    ]
 
-    except (OSError, ValueError) as e:
-        log.debug('Failed to get torrent info: %s', e)
-        return _format_film_simple(film, torrents)
+    if torrents:
+        torrents_block = _format_torrents_lines(torrents, film)
+        if len(torrents_block) > 4000:
+            torrents_block = torrents_block[:3997] + '…'
+        notifications.append(
+            {
+                'type': 'text',
+                'media': None,
+                'caption': torrents_block,
+                'reply_markup': _format_torrents_buttons(torrents, film),
+            }
+        )
+
+    return notifications
 
 
-def _format_film_simple(film: Film, torrents: list[Any]) -> Notification:
-    """Simple film format without detailed info"""
-    safe_name = html.escape(film.name)
-    text = f'🎬 <b>{safe_name}</b> ({film.year})'
-    markup = _format_torrents_buttons(torrents, film)
-    return {
-        'type': 'text',
-        'media': None,
-        'caption': text,
-        'reply_markup': markup,
-    }
+def _parse_rating(value: str | float | None) -> float | None:
+    """Parse Film.rating (stored as string) into a float; tolerate empty / non-numeric."""
+    if value is None:
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        return float(stripped)
+    except ValueError:
+        return None
 
 
 async def format_films(films: Iterable[Film]) -> list[Notification]:
@@ -163,8 +437,6 @@ async def format_films(films: Iterable[Film]) -> list[Notification]:
             if not torrents:
                 continue
 
-            # Format film with details or simple format
-            notification = await _format_film_with_details(session, film, torrents)
-            notifications.append(notification)
+            notifications.extend(await _format_film_card(session, film, torrents))
 
     return notifications

--- a/src/telegram_rutor_bot/helpers.py
+++ b/src/telegram_rutor_bot/helpers.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
-    from telegram_rutor_bot.db.models import Film
+    from telegram_rutor_bot.db.models import Film, Torrent
 
 
 def gen_hash(text: str, prefix: str | None = None) -> str:
@@ -80,7 +80,7 @@ def _keyword_match_count(name: str, keywords: list[str]) -> int:
     return sum(1 for kw in keywords if kw in lowered)
 
 
-def _sorted_torrents(torrents: list[Any], film: Film | None = None) -> list[Any]:
+def _sorted_torrents(torrents: list[Torrent], film: Film | None = None) -> list[Torrent]:
     """Sort torrents for display.
 
     Primary axis (configurable, applied within season/episode for tv):
@@ -96,30 +96,30 @@ def _sorted_torrents(torrents: list[Any], film: Film | None = None) -> list[Any]
     """
     keywords = _sort_keywords()
 
-    def _quality_key(t: Any) -> tuple[int, int, int]:  # noqa: ANN401 - SQLAlchemy Torrent row, attribute-based access
+    def _quality_key(t: Torrent) -> tuple[int, int, int]:
         # Negate "more is better" axes so Python's ascending sort puts them first.
-        score = _keyword_match_count(getattr(t, 'name', '') or '', keywords)
-        seeds = getattr(t, 'seeds', None) or 0
-        size = getattr(t, 'sz', 0) or 0
+        score = _keyword_match_count(t.name or '', keywords)
+        seeds = t.seeds or 0
+        size = t.sz or 0
         return (-score, -seeds, size)
 
-    is_tv = bool(film and getattr(film, 'tmdb_media_type', None) == 'tv')
+    is_tv = bool(film and film.tmdb_media_type == 'tv')
     if is_tv:
         return sorted(
             torrents,
             key=lambda t: (
-                getattr(t, 'season', None) or float('inf'),
-                getattr(t, 'episode', None) or 0,
+                t.season if t.season is not None else float('inf'),
+                t.episode or 0,
                 *_quality_key(t),
             ),
         )
     return sorted(torrents, key=_quality_key)
 
 
-def _episode_tag(t: Any) -> str:  # noqa: ANN401 - SQLAlchemy Torrent row, attribute-based access
+def _episode_tag(t: Torrent) -> str:
     """`S01E02` / `S01` / `` based on what the parser stored on the torrent."""
-    season = getattr(t, 'season', None)
-    episode = getattr(t, 'episode', None)
+    season = t.season
+    episode = t.episode
     if season and episode:
         return f'S{int(season):02d}E{int(episode):02d}'
     if season:
@@ -131,7 +131,7 @@ _NUM_BUTTON_EMOJI = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6�
 _BUTTONS_PER_ROW = 2
 
 
-def _format_torrents_lines(torrents: list[Any], film: Film) -> str:
+def _format_torrents_lines(torrents: list[Torrent], film: Film) -> str:
     """Render a numbered list of releases — one HTML line per torrent.
 
     Each line is `<numeric_emoji> <a href="rutor_url">size · seeds · tag · release</a>`.
@@ -166,7 +166,7 @@ def _format_torrents_lines(torrents: list[Any], film: Film) -> str:
     return '\n'.join(lines)
 
 
-def _format_torrents_buttons(torrents: list[Any], film: Film) -> InlineKeyboardMarkup:
+def _format_torrents_buttons(torrents: list[Torrent], film: Film) -> InlineKeyboardMarkup:
     """Number + size + seeds on each button — paired with the per-line list in caption.
 
     Layout per button: `{number_emoji} {size} 🌱{seeds}` (e.g. `1️⃣ 14.7GB 🌱29`).
@@ -356,7 +356,7 @@ def _build_film_caption(film: Film, details: dict[str, Any] | None = None) -> st
     )
 
 
-async def _format_film_card(session: AsyncSession, film: Film, torrents: list[Any]) -> list[Notification]:
+async def _format_film_card(session: AsyncSession, film: Film, torrents: list[Torrent]) -> list[Notification]:
     """Render a film as two messages: poster + TMDB info, then the releases list.
 
     Splitting frees us from the 1024-char photo-caption budget: the full TMDB blurb

--- a/src/telegram_rutor_bot/main.py
+++ b/src/telegram_rutor_bot/main.py
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 _background_tasks: set[asyncio.Task[Any]] = set()
 
 
-async def run_bot() -> None:
+async def run_bot() -> None:  # noqa: PLR0915 - linear handler registration; splitting hurts readability
     """Run the Telegram bot in async mode"""
     # Sync config
     await refresh_settings_from_db()
@@ -67,6 +67,7 @@ async def run_bot() -> None:
     application.add_handler(CommandHandler('list_subscriptions', h.subscriptions_list))
     application.add_handler(CommandHandler('downloads', h.torrent_downloads))
     application.add_handler(CommandHandler('recommend', h.torrent_recommend))
+    application.add_handler(CommandHandler('discovery', h.discovery_command))
     application.add_handler(MessageHandler(filters.TEXT & filters.Regex(r'^(/dl_\d+)$'), h.torrent_download))
     application.add_handler(MessageHandler(filters.TEXT & filters.Regex(r'^(/in_\d+)$'), h.torrent_info))
     application.add_handler(MessageHandler(filters.TEXT & filters.Regex(r'^(/ds_\d+)$'), h.search_delete))
@@ -77,6 +78,8 @@ async def run_bot() -> None:
     application.add_handler(CommandHandler('language', h.language_handler))
     application.add_handler(CallbackQueryHandler(h.search_callback_handler, pattern=r'^(ds_|es_|sub_|unsub_)'))
     application.add_handler(CallbackQueryHandler(h.set_language_callback, pattern='^lang_'))
+    application.add_handler(CallbackQueryHandler(h.discovery_season_callback_handler, pattern=r'^disc_season:'))
+    application.add_handler(CallbackQueryHandler(h.discovery_callback_handler, pattern=r'^disc_rutor:'))
     application.add_handler(CallbackQueryHandler(h.callback_query_handler))
     application.add_handler(MessageHandler(filters.COMMAND, h.unknown))
 

--- a/src/telegram_rutor_bot/rutor/formatter.py
+++ b/src/telegram_rutor_bot/rutor/formatter.py
@@ -143,4 +143,4 @@ def format_torrent_message(
         _format_links_section(download_command, result.get('imdb_url'), result.get('kp_url'), page_link)
     )
 
-    return '\\n'.join(message_parts)
+    return '\n'.join(message_parts)

--- a/src/telegram_rutor_bot/rutor/parser.py
+++ b/src/telegram_rutor_bot/rutor/parser.py
@@ -155,6 +155,7 @@ def _extract_torrent_data(lnk: Tag) -> dict[str, Any] | None:
         return None
     tds = row.find_all('td')
     size = size_to_bytes_converter(tds[-2].get_text())
+    seeds = _extract_seeds(tds[-1])
 
     try:
         date = datetime.strptime(tds[0].get_text(), '%d\xa0%b\xa0%y').replace(tzinfo=UTC).date()
@@ -186,7 +187,26 @@ def _extract_torrent_data(lnk: Tag) -> dict[str, Any] | None:
         'name': name,
         'original_name': original_name,
         'blake': blake,
+        'seeds': seeds,
     }
+
+
+def _extract_seeds(td: Any) -> int:  # noqa: ANN401 - BeautifulSoup Tag-or-NavigableString boundary
+    """Pull the seed count from a search-result row's last td.
+
+    Layout: `<span class="green">N</span> ... <span class="red">M</span>`
+    where green = seeds, red = leechers. Returns 0 when the cell is missing
+    or unparseable so callers can rely on an int.
+    """
+    if not hasattr(td, 'find'):
+        return 0
+    span = td.find('span', class_='green')
+    if not span:
+        return 0
+    try:
+        return int(span.get_text(strip=True))
+    except (TypeError, ValueError):
+        return 0
 
 
 async def _process_torrent_item(
@@ -222,6 +242,7 @@ async def _process_torrent_item(
             created=datetime.combine(torrent_data['date'], datetime.min.time()).replace(tzinfo=UTC),
             link=torrent_data['torrent_lnk'],
             sz=torrent_data['size'],
+            seeds=torrent_data.get('seeds'),
             approved=False,
             downloaded=False,
             season=ep_info.season if ep_info else None,
@@ -239,6 +260,7 @@ async def _process_torrent_item(
                 torrent_id=existing.id,
                 name=torrent_data['torrent'].get_text(),
                 sz=torrent_data['size'],
+                seeds=torrent_data.get('seeds') or 0,
             )
         await session.commit()
 
@@ -246,8 +268,13 @@ async def _process_torrent_item(
     # We do this after committing the torrent to ensure basic data is saved
     # even if enrichment fails or is slow.
     # We only enrich if we have the film object (i.e. it wasn't cached)
-    if 'film' in locals() and film and not film.poster:
-        await enrich_film_data(session, film, torrent_data['torrent_lnk'])
+    if 'film' in locals() and film:
+        if not film.poster:
+            await enrich_film_data(session, film, torrent_data['torrent_lnk'])
+        # Also try TMDB match for the freshly-created film so the discovery /
+        # search rendering paths get a poster + original_title + ratings.
+        if not film.tmdb_id:
+            await _try_match_tmdb(session, film)
 
 
 async def fetch_rutor_torrents(
@@ -403,6 +430,17 @@ async def _handle_single_torrent(
     # Check if torrent already exists
     existing_torrent = await get_torrent_by_blake(session, torrent_data['torrent_lnk_blake'])
     if existing_torrent:
+        # Refresh seeds + size on every parse so the library always shows current numbers,
+        # even though we don't re-create the torrent or notify subscribers.
+        new_seeds = torrent_data.get('seeds') or 0
+        if existing_torrent.seeds != new_seeds or existing_torrent.sz != torrent_data['size']:
+            await modify_torrent(
+                session,
+                torrent_id=existing_torrent.id,
+                seeds=new_seeds,
+                sz=torrent_data['size'],
+            )
+            await session.commit()
         log.info('Skipping %s: Already exists', torrent_data['name'])
         return
 
@@ -430,6 +468,36 @@ async def _handle_single_torrent(
 
     await _process_torrent_item(session, torrent_data, film_cache, new, category_id, film_id, is_series)
     log.info('Processed %s: Added/Updated', torrent_data['name'])
+
+
+async def _try_match_tmdb(session: AsyncSession, film: Film) -> None:
+    """Best-effort TMDB lookup for a fresh film row — fills tmdb_id/original_title/poster/rating."""
+    # Imported here to avoid a circular import (services.matcher imports db.films which
+    # ends up importing this parser via the db package's __init__ chain).
+    from telegram_rutor_bot.services.matcher import TmdbMatcher  # noqa: PLC0415
+
+    try:
+        matcher = TmdbMatcher(session)
+        match = await matcher._try_find_tmdb_match(film)
+    except Exception as e:
+        log.warning('TMDB match skipped for film %s (%r): %s', film.id, film.name, e)
+        return
+
+    if not match:
+        return
+
+    rating = match.get('vote_average')
+    # Prefer the TMDB poster path even if rutor already supplied one — TMDB is the
+    # canonical, higher-quality source and Discovery rendering already understands it.
+    await update_film_metadata(
+        session,
+        film_id=film.id,
+        tmdb_id=match['id'],
+        tmdb_media_type='movie',
+        original_title=match.get('original_title') or match.get('original_name'),
+        poster=match.get('poster_path'),
+        rating=float(rating) if rating is not None else None,
+    )
 
 
 async def enrich_film_data(session: AsyncSession, film: Film, torrent_link: str) -> None:

--- a/src/telegram_rutor_bot/rutor/parser.py
+++ b/src/telegram_rutor_bot/rutor/parser.py
@@ -191,17 +191,15 @@ def _extract_torrent_data(lnk: Tag) -> dict[str, Any] | None:
     }
 
 
-def _extract_seeds(td: Any) -> int:  # noqa: ANN401 - BeautifulSoup Tag-or-NavigableString boundary
+def _extract_seeds(td: Tag) -> int:
     """Pull the seed count from a search-result row's last td.
 
     Layout: `<span class="green">N</span> ... <span class="red">M</span>`
     where green = seeds, red = leechers. Returns 0 when the cell is missing
     or unparseable so callers can rely on an int.
     """
-    if not hasattr(td, 'find'):
-        return 0
     span = td.find('span', class_='green')
-    if not span:
+    if not isinstance(span, Tag):
         return 0
     try:
         return int(span.get_text(strip=True))

--- a/src/telegram_rutor_bot/schemas.py
+++ b/src/telegram_rutor_bot/schemas.py
@@ -14,7 +14,7 @@ class Notification(TypedDict):
     type: Literal['photo', 'text']
     media: bytes | str | None
     caption: str
-    reply_markup: InlineKeyboardMarkup
+    reply_markup: InlineKeyboardMarkup | None
 
 
 class UserResponse(BaseModel):

--- a/src/telegram_rutor_bot/services/monitor.py
+++ b/src/telegram_rutor_bot/services/monitor.py
@@ -97,11 +97,13 @@ class WatchlistMonitor:
         for film in films:
             log.info(f'Checking monitored film: {film.name}')
             try:
-                # Construct search URL
-                # Search by original title + year to be specific, or just name?
-                # Using name from DB.
-                query = film.name
-                url = f'{RUTOR_BASE_URL}/search/0/0/0/0/{quote(query)}'
+                # Construct search URL.
+                # 3rd path segment must be /100/ — /0/ and /000/ silently exclude
+                # HD video releases on rutor (admin posts only get returned).
+                query = film.original_title or film.name
+                if film.year:
+                    query = f'{query} {film.year}'
+                url = f'{RUTOR_BASE_URL}/search/0/0/100/0/{quote(query)}'
 
                 # parse_rutor handles filtering (via settings) and DB saving
                 new_ids = await parse_rutor(url, self.session, is_series=(film.tmdb_media_type == 'tv'))

--- a/src/telegram_rutor_bot/tasks/jobs.py
+++ b/src/telegram_rutor_bot/tasks/jobs.py
@@ -1,6 +1,7 @@
 """TaskIQ tasks for scheduled jobs"""
 
 import contextlib
+import html
 import logging
 import traceback
 from datetime import UTC, datetime
@@ -21,6 +22,7 @@ from telegram_rutor_bot.db import (
     get_search_subscribers,
     get_searches,
     get_user,
+    get_user_by_chat,
     update_last_success,
 )
 from telegram_rutor_bot.db.models import Film, Search, TaskExecution, User, subscribes_table
@@ -29,7 +31,7 @@ from telegram_rutor_bot.rutor import parse_rutor
 from telegram_rutor_bot.rutor.constants import RUTOR_BASE_URL
 from telegram_rutor_bot.services.watchlist import check_matches
 from telegram_rutor_bot.torrent_clients import get_torrent_client
-from telegram_rutor_bot.utils import send_notifications
+from telegram_rutor_bot.utils import DEFAULT_LANGUAGE, get_text, send_notifications
 
 from .broker import broker
 
@@ -279,34 +281,84 @@ async def execute_search(
 async def search_film_on_rutor(
     film_id: int,
     query: str,
-    requester_chat_id: int | None = None,  # pylint: disable=unused-argument
+    requester_chat_id: int | None = None,
 ) -> None:
     """Execute a search for a specific film on Rutor"""
     log.info('Executing film search for film %s with query "%s"', film_id, query)
 
-    # Construct Rutor URL
-    # We need a proper URL construction logic.
-    # Usually it is https://rutor.info/search/0/0/000/0/{query}
+    # Construct Rutor URL.
+    # The 3rd path segment is rutor's category code: /100/ matches "all categories"
+    # AND surfaces real torrents; /000/ and /0/ silently exclude HD video releases
+    # (rutor returns admin posts only).
     safe_query = query.replace(' ', '+')  # simple encoding
-    url = f'{RUTOR_BASE_URL}/search/0/0/000/0/{safe_query}'
+    url = f'{RUTOR_BASE_URL}/search/0/0/100/0/{safe_query}'
 
     async with get_async_session() as session:
         try:
-            # We don't track this as a "Search" entity in DB (which is for subscribed searches),
-            # but we could track it as a TaskExecution if we had a generic task model.
-            # For now, just run it.
+            # Pull tmdb_media_type so the parser extracts S01E02 markers for TV titles
+            # (movies skip episode parsing — same flag drives the watchlist monitor too).
+            film_row = await session.get(Film, film_id)
+            is_series = bool(film_row and film_row.tmdb_media_type == 'tv')
 
-            new_ids = await parse_rutor(url, session, film_id=film_id)
+            new_ids = await parse_rutor(url, session, film_id=film_id, is_series=is_series)
 
             log.info('Film search %s finished. Found %s torrents.', film_id, len(new_ids))
 
-            # Notify requester if needed?
-            # The UI triggers this, so maybe just log it.
-            # If we want to notify via ws, we need a mechanism.
-            # For now, rely on simply adding to DB.
+            await _notify_film_search_requester(session, film_id, new_ids, requester_chat_id)
 
         except Exception as e:  # pylint: disable=broad-exception-caught
             log.exception('Film search failed: %s', e)
+
+
+async def _notify_film_search_requester(
+    session: AsyncSession,
+    film_id: int,
+    new_ids: list[int],
+    requester_chat_id: int | None,
+) -> None:
+    """DM the discovery requester about the rutor refresh — only on net-new finds or empty result."""
+    if requester_chat_id is None:
+        return
+
+    token = settings.telegram_token
+    if not token:
+        log.info('Telegram token not set, skipping film search notification for film %s', film_id)
+        return
+
+    bot = Bot(token=token)
+
+    user = await get_user_by_chat(session, requester_chat_id)
+    lang = user.language if user else DEFAULT_LANGUAGE
+
+    film = await session.get(Film, film_id)
+
+    if not new_ids:
+        if film is None:
+            message = get_text('discovery_refresh_no_new_no_film', lang)
+            await _notify_requester(bot, requester_chat_id, message)
+            return
+        # Plain-text path via _notify_requester — keep film name raw, no HTML escaping needed.
+        plain_title = film.name or ''
+        year_str = str(film.year) if film.year else '—'
+        message = get_text('discovery_refresh_no_new', lang, title=plain_title, year=year_str)
+        await _notify_requester(bot, requester_chat_id, message)
+        return
+
+    if film is None:
+        log.warning('Film %s vanished while building rutor refresh notification', film_id)
+        return
+
+    # Header is sent with ParseMode.HTML, so escape the film name once at the boundary.
+    safe_title = html.escape(film.name or '')
+    year_str = str(film.year) if film.year else '—'
+    header = get_text('discovery_refresh_new_header', lang, title=safe_title, year=year_str, count=len(new_ids))
+
+    with contextlib.suppress(telegram_error.TelegramError):
+        await bot.send_message(requester_chat_id, header, parse_mode=ParseMode.HTML)
+
+    notifications = await format_films([film])
+    with contextlib.suppress(telegram_error.TelegramError):
+        await send_notifications(bot, requester_chat_id, notifications)
 
 
 async def _notify_requester(bot: Bot, chat_id: int | None, message: str) -> None:

--- a/src/telegram_rutor_bot/utils/i18n.py
+++ b/src/telegram_rutor_bot/utils/i18n.py
@@ -53,6 +53,22 @@ TRANSLATIONS = {
         'cron_dow_4': 'Thursday',
         'cron_dow_5': 'Friday',
         'cron_dow_6': 'Saturday',
+        'discovery_usage': 'Usage: /discovery <title>',
+        'discovery_no_results': 'No results found in TMDB',
+        'discovery_results_header': 'Found in TMDB:',
+        'discovery_tv_not_supported': 'TV shows are not yet supported by /discovery — only movies for now.',
+        'discovery_search_started': (
+            '🔎 Started a rutor search for <b>{title}</b> ({year}). I will ping you when torrents show up.'
+        ),
+        'discovery_existing_from_db': ('🎬 <b>{title}</b> ({year}) — {count} torrent(s) in your library.'),
+        'discovery_refresh_no_new': '🔎 No new torrents on rutor for «{title}» ({year}).',
+        'discovery_refresh_no_new_no_film': '🔎 No new torrents on rutor.',
+        'discovery_refresh_new_header': '🆕 {count} new torrent(s) on rutor for «{title}» ({year}):',
+        'discovery_tmdb_error': 'Could not query TMDB right now. Please try again later.',
+        'btn_discovery_pick_torrents': '🔎 Find torrents on rutor',
+        'btn_discovery_pick_seasons': '📺 Pick a season',
+        'btn_discovery_all_seasons': '🔎 All seasons',
+        'btn_discovery_season': '📺 S{n}',
     },
     'ru': {
         'start_message': 'Привет! Я Rutor Bot. Выбери действие в меню:',
@@ -101,6 +117,22 @@ TRANSLATIONS = {
         'cron_dow_4': 'Чт',
         'cron_dow_5': 'Пт',
         'cron_dow_6': 'Сб',
+        'discovery_usage': 'Использование: /discovery <название>',
+        'discovery_no_results': 'Ничего не найдено в TMDB',
+        'discovery_results_header': 'Найдено в TMDB:',
+        'discovery_tv_not_supported': 'Сериалы пока не поддерживаются командой /discovery — только фильмы.',
+        'discovery_search_started': (
+            '🔎 Запустил поиск на rutor для <b>{title}</b> ({year}). Пришлю, когда найду торренты.'
+        ),
+        'discovery_existing_from_db': ('🎬 <b>{title}</b> ({year}) — {count} торрентов в библиотеке.'),
+        'discovery_refresh_no_new': '🔎 По «{title}» ({year}) новых торрентов на rutor не найдено.',
+        'discovery_refresh_no_new_no_film': '🔎 Новых торрентов на rutor не найдено.',
+        'discovery_refresh_new_header': '🆕 По «{title}» ({year}) {count} новых торрентов на rutor:',
+        'discovery_tmdb_error': 'Не удалось обратиться к TMDB. Попробуйте позже.',
+        'btn_discovery_pick_torrents': '🔎 Найти торренты на rutor',
+        'btn_discovery_pick_seasons': '📺 Выбрать сезон',
+        'btn_discovery_all_seasons': '🔎 Все сезоны',
+        'btn_discovery_season': '📺 С{n}',
     },
 }
 

--- a/src/telegram_rutor_bot/utils/telegram.py
+++ b/src/telegram_rutor_bot/utils/telegram.py
@@ -35,6 +35,9 @@ async def send_notifications(
                         text=note['caption'],
                         parse_mode=ParseMode.HTML,
                         reply_markup=note['reply_markup'],
+                        # Suppress rutor link preview — release-name links are an action
+                        # affordance, not content the user wants to preview inline.
+                        disable_web_page_preview=True,
                     )
             except TelegramError as e:
                 log.error('Failed to send notification to %s: %s', chat_id, e)

--- a/src/telegram_rutor_bot/web/config_api.py
+++ b/src/telegram_rutor_bot/web/config_api.py
@@ -68,6 +68,7 @@ class ConfigSetupRequest(BaseModel):
     torrent: TorrentConfig
     tmdb_api_key: str | None = None
     tmdb_session_id: str | None = None
+    torrent_sort_keywords: str | None = None
     seed_ratio_limit: float = 1.0
     seed_time_limit: int = 2880
     inactive_seeding_time_limit: int = 0
@@ -105,6 +106,7 @@ async def get_config() -> ConfigCheckResponse:
         'transmission_username': db_config.transmission_username,
         'tmdb_api_key': db_config.tmdb_api_key,
         'tmdb_session_id': db_config.tmdb_session_id,
+        'torrent_sort_keywords': db_config.torrent_sort_keywords,
     }
 
     # Fetch live limits from qBittorrent
@@ -247,6 +249,8 @@ async def save_config(config: ConfigSetupRequest) -> ConfigCheckResponse:
         updates['tmdb_api_key'] = config.tmdb_api_key
     if config.tmdb_session_id:
         updates['tmdb_session_id'] = config.tmdb_session_id
+    # Persist torrent sort keywords as-is (None / '' clears the preference).
+    updates['torrent_sort_keywords'] = config.torrent_sort_keywords or None
 
     # Save to DB
     async with get_async_session() as session:


### PR DESCRIPTION
## Summary

- New Telegram `/discovery` command — TMDB multi-search → per-film pick cards with poster, original/localized title, ratings, runtime, seasons, director, cast, overview. Movie cards trigger rutor parse; TV cards open a season picker before parsing.
- DB-first rendering: callbacks show existing torrents from the local library; rutor refresh runs only when nothing matches. Worker DMs the requester on net-new finds (or empty result).
- Single canonical render path through `helpers._format_film_card` — used by /discovery, /search, watchlist monitor, subscription notifications.
- Rutor parser: switched search URL category from `/000/` (silently dropped HD video) to `/100/`; extract seeds from green span; refresh seeds on every pass; auto-match new films to TMDB; fix `'\\\\n'.join` typo that produced single-line cached blobs.
- Discovery web UI: modal renders the same field set as Telegram cards (director / cast / seasons / original title); icon-only action buttons with Tooltips; `/api/discovery/library` filters out unmatched films so the modal can't fetch random TMDB rows by collision; missing EN locale keys added.
- Configurable display sort via `config.torrent_sort_keywords` (Alembic `c4a8f0d2e7b1`): `(-keyword_match_count, -seeds, +size)`. TV keeps `(season, episode)` as outer key.
- Misc: parametrised SQL for film search (rolled in from earlier hotfix), Postgres-compatible `SELECT ... ORDER BY` rewrite, year-range regex in `_clean_torrent_name`, TV-aware search query (drops year, accepts season).

## Test plan

- [ ] Run `alembic upgrade head` on a fresh DB → `config.torrent_sort_keywords` column exists.
- [ ] Open Web UI → Settings → fill `Torrent sort keywords` (e.g. `LostFilm, BDRip`) → reload, value persisted.
- [ ] Telegram `/discovery <movie title>` → 5 picker cards, each with poster + full TMDB info + single button. Pick one → DB-existing flow OR rutor-parse with notification on completion.
- [ ] Telegram `/discovery <tv title>` → cards, click a TV one → season picker appears (Все сезоны + S1..SN). Pick a season → torrent list scoped to that season.
- [ ] Web UI Discovery → click a film → modal shows director, cast, seasons (for tv), original title in header; action buttons are icon-only with tooltips, no overflow.
- [ ] Sorting: with keywords set, releases matching more keywords surface first; with keywords cleared, seedier+smaller wins ties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)